### PR TITLE
Erstatte Klient-type med application_type iht. API-spek

### DIFF
--- a/_docs/ID-porten/oidc/oidc_func_clientreg.md
+++ b/_docs/ID-porten/oidc/oidc_func_clientreg.md
@@ -114,7 +114,7 @@ Merk at klient-type ikke blir lagret som del av klient-registreringen, men utled
 Tabellen under oppsummerer sammenhengen mellom de ulike egenskapene:
 
 
-| Integrasjon | Klient-type |  tillatte token_endpoint_auth_method | tillatte grant_types | scope | Kan legge til scopes? |
+| Integrasjon | application_type |  tillatte token_endpoint_auth_method | tillatte grant_types | scope | Kan legge til scopes? |
 |-|-|-|-|-|-|
 |ID-porten| web |  client_secret_basic client_secret_post private_key_jwt      | authorization_code refresh_token  |openid profile | nei |
 ||  browser |  none     | authorization_code   |openid profile | nei |


### PR DESCRIPTION
Erstatte Klient-type med application_type i Oversikt over kombinasjonar-tabellen iht. API-spesifikasjonen (External OIDC oidc-client-controller)