### PR TITLE
Update maskinporten_guide_apitilbyder.md

### DIFF
--- a/_docs/Maskinporten/maskinporten_guide_apitilbyder.md
+++ b/_docs/Maskinporten/maskinporten_guide_apitilbyder.md
@@ -34,7 +34,7 @@ Send inn skjema: [https://forms.office.com/Pages/ResponsePage.aspx?id=D1aOAK8I7E
 
 #### Beskrivelse av APIer
 
-I Maskinporten-sammenheng er et API det samme som et Oauth2 scope.Digitaliseringsdirektoratet ønsker å gi API-tilbydere stor frihet til å selv bestemme sin semantikk for API-sikring innenfor rammene av Oauth2-standardene. Samtidig er det behov for noen regler for å sikre interoperabilitet.  
+I Maskinporten-sammenheng er et API det samme som et Oauth2 scope. Digitaliseringsdirektoratet ønsker å gi API-tilbydere stor frihet til å selv bestemme sin semantikk for API-sikring innenfor rammene av Oauth2-standardene. Samtidig er det behov for noen regler for å sikre interoperabilitet.  
 
 Følgende syntax brukes:
 
@@ -57,7 +57,7 @@ Attributtet `visibilty` brukes for å angi scopets synlighet:
 |-|-|
 |PUBLIC | Scopet er synlig for alle på /scopes/all endepunkt.    |
 |PRIVATE| Scopet er ikke synlig for andre enn API-tilbyder og de konsuementer som har fått tilgang |Konsument må bli fortalt at scopet finnes    |
-|INTERAL | Inten bruk iDigitaliseringsdirektoratet   |   
+|INTERAL | Inten bruk i Digitaliseringsdirektoratet   |   
 
 Merk at det er ingen integrasjon med API-katalogen, slik at API-tilbyder selv må sikre at scopet ikke havner i API-katalogen dersom denne benyttes.
 
@@ -67,7 +67,7 @@ Det anbefales at man setter en begrensning på bruk av scopet. Ved å sette attr
 
 #### Inaktive entiteter
 
-For å sikre juridisk logging og statistikk, vilDigitaliseringsdirektoratet aldri slette scopes og tilganer (eller integrasjoner), men heller deaktivere disse ved DELETE-kall.
+For å sikre juridisk logging og statistikk, vil Digitaliseringsdirektoratet aldri slette scopes og tilganer (eller integrasjoner), men heller deaktivere disse ved DELETE-kall.
 
 Deaktiverte entiteter vil ikke komme opp i GET utlistinger som default, men kan hentes ved å sette `inactive=TRUE` som query parameter. Deaktiverte entiteter vil ikke reaktiveres ved POST og man får 409 Conflict isteden.
 


### PR DESCRIPTION
La inn mellomrom før "Digitaliseringsdirektoratet" da dette nok ved en feil har blitt utelatt flere plasser.