### PR TITLE
Winsw XML configuration updates and limited user EventLog rights

### DIFF
--- a/_docs/eFormidling/installasjon/eformidling_ip_run.md
+++ b/_docs/eFormidling/installasjon/eformidling_ip_run.md
@@ -95,6 +95,12 @@ Når en skal starte integrasjonspunktet så kreves det visse rettigheter på den
 Egenskaper på mappen
   * Security:
     * Legg til integrasjonspunkt brukeren med modify rettigheter
+    
+**Bruker må ha modify tilgang på Windows EventLog**
+
+Registry Editor
+  * Permissions på HKEY_LOCAL_MACHINE\SYSTEM\CurrentControlSet\Services\EventLog
+  * Legg til integrasjonspunkt brukeren med modify rettigheter på Security "mappe".
   
 ### Kjøre kommandoen i "Task Scheduler"
 

--- a/resources/eformidling/integrasjonspunkt-staging.xml
+++ b/resources/eformidling/integrasjonspunkt-staging.xml
@@ -1,16 +1,19 @@
 <service>
-            <id>integrasjonspunkt</id>
-            <name>integrasjonspunkt for einnsyn og eformidling</name>
-            <description>Oppsett for testmiljø</description>
-            <argument>-jar</argument>
-			<argument>-Dspring.profiles.active=staging</argument>
-            <argument>integrasjonspunkt-2.0.10.jar</argument>
-      	    <argument>-Xmx2048m</argument>
-            <logpath>%BASE%/integrasjonspunkt-logs</logpath>
-			<log mode="roll-by-size">
-				<sizeThreshold>10240</sizeThreshold>
-				<keepFiles>8</keepFiles>
-			</log>
-            <executable>java</executable>
-</service> 
- 
+    <id>integrasjonspunkt</id>
+    <name>integrasjonspunkt for einnsyn og eformidling</name>
+    <description>Oppsett for testmiljø</description>
+    <workingdirectory>%BASE%</workingdirectory>
+	
+    <argument>-jar</argument>
+    <argument>-Dspring.profiles.active=staging</argument>
+    <argument>%BASE%/integrasjonspunkt-2.1.0.jar</argument>
+    <argument>-Xmx2048m</argument>
+    
+    <logpath>%BASE%/integrasjonspunkt-logs</logpath>
+    <log mode="roll-by-size">
+        <sizeThreshold>10240</sizeThreshold>
+	<keepFiles>8</keepFiles>
+    </log>
+    
+    <executable>java</executable>
+</service>


### PR DESCRIPTION
Hi,

This pull request updates the documentation slightly to include a change I had to make to get the service running succesfully on windows, using winsw.exe.  The application writes to the EventLog but after setting up a limited rights user, I found I also had to give it permission to modify and read from the windows eventlog.  It needs read access to all logs to make sure it is trying to use a unique source name, and write access to write to the Security log.

I also had some issues with the XML configuration.  Using the absolute url to the jar file by use of the %BASE% variable fixed that error, and the second error was that the properties file could not be found.  Setting the working directory property in the XML configuration fixed this.