### PR TITLE
Korriger schema

### DIFF
--- a/schemas/common/sbdh.schema.json
+++ b/schemas/common/sbdh.schema.json
@@ -1,6 +1,6 @@
 {
 	"id": "https://docs.digdir.no/schemas/common/sbdh.schema.json",
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "https://json-schema.org/draft-07/schema#",
 	"description": "Schema for Standard business document header (SBD) brukt av Digdir",
 	"definitions": {
 		"standardBusinessDocumentHeader": {

--- a/schemas/common/sbdh.schema.json
+++ b/schemas/common/sbdh.schema.json
@@ -1,8 +1,8 @@
 {
-	"id": "http://docs.digdir.no/schemas/common/sbdh.schema.json",
+	"id": "https://docs.digdir.no/schemas/common/sbdh.schema.json",
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"description": "Schema for Standard business document header (SBD) brukt av Digdir",
-	"definitions": {		
+	"definitions": {
 		"standardBusinessDocumentHeader": {
 			"type": "object",
             "$id": "#/definitions/standardBusinessDocumentHeader",

--- a/schemas/dpi/aapningskvittering.schema.json
+++ b/schemas/dpi/aapningskvittering.schema.json
@@ -1,6 +1,6 @@
 {
 	"id": "https://docs.digdir.no/schemas/dpi/aapningskvittering.schema.json",
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "https://json-schema.org/draft-07/schema#",
 	"description": "En KvitteringsMelding til Avsender om at Mottaker har åpnet forsendelsen i sin postkasse.",
 	"$comment": "Åpningskvitteringer blir bare sendt dersom dette er bestilt av Avsender i digital post meldingen ved å spesifisere dette i digitalpostinfo. Mottaker må aksepteres at det sendes en ÅpningsKvittering til Avsender for å få lest den digital posten. Mangel på ÅpningsKvittering betyr at Mottaker ikke har lest dokumentet.",
 	"definitions": {

--- a/schemas/dpi/aapningskvittering.schema.json
+++ b/schemas/dpi/aapningskvittering.schema.json
@@ -1,5 +1,5 @@
 {
-	"id": "http://docs.digdir.no/schemas/dpi/aapningskvittering.schema.json",
+	"id": "https://docs.digdir.no/schemas/dpi/aapningskvittering.schema.json",
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"description": "En KvitteringsMelding til Avsender om at Mottaker har åpnet forsendelsen i sin postkasse.",
 	"$comment": "Åpningskvitteringer blir bare sendt dersom dette er bestilt av Avsender i digital post meldingen ved å spesifisere dette i digitalpostinfo. Mottaker må aksepteres at det sendes en ÅpningsKvittering til Avsender for å få lest den digital posten. Mangel på ÅpningsKvittering betyr at Mottaker ikke har lest dokumentet.",
@@ -10,16 +10,16 @@
 			"title": "kvittering",
 			"properties": {
 				"avsender": {
-					"$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/avsender"
+					"$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/avsender"
 				},
 				"mottaker": {
-					"$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/virksomhetmottaker"
+					"$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/virksomhetmottaker"
 				},
 				"maskinportentoken": {
-					"$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/maskinportentoken"
+					"$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/maskinportentoken"
 				},
 				"tidspunkt": {
-					"$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/tidspunkt"
+					"$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/tidspunkt"
 				}
 			},
 			"required": [

--- a/schemas/dpi/commons.schema.json
+++ b/schemas/dpi/commons.schema.json
@@ -1,6 +1,6 @@
 {
     "id": "https://docs.digdir.no/schemas/dpi/commons.schema.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "description": "Schema for kvittering brukt av Digdir innenfor Digital post til innbygger (DPI)",
     "definitions": {
         "avsender": {

--- a/schemas/dpi/commons.schema.json
+++ b/schemas/dpi/commons.schema.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://docs.digdir.no/schemas/dpi/commons.schema.json",
+    "id": "https://docs.digdir.no/schemas/dpi/commons.schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "Schema for kvittering brukt av Digdir innenfor Digital post til innbygger (DPI)",
     "definitions": {

--- a/schemas/dpi/digitalpost.schema.json
+++ b/schemas/dpi/digitalpost.schema.json
@@ -1,5 +1,5 @@
 {
-	"id": "http://docs.digdir.no/schemas/dpi/digitalpost.schema.json",
+	"id": "https://docs.digdir.no/schemas/dpi/digitalpost.schema.json",
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"description": "Schema for Standard business document (SBD) brukt av Digdir",
 	"definitions": {
@@ -196,7 +196,7 @@
 					"$ref": "#/definitions/mottaker"
 				},
 				"dokumentpakkefingeravtrykk": {
-					"$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/dokumentpakkefingeravtrykk"
+					"$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/dokumentpakkefingeravtrykk"
 				},
 				"maskinportentoken": {
 					"type": "string",
@@ -446,7 +446,7 @@
 					"$ref": "#/definitions/mottaker"
 				},
 				"dokumentpakkefingeravtrykk": {
-					"$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/dokumentpakkefingeravtrykk"
+					"$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/dokumentpakkefingeravtrykk"
 				},
 				"maskinportentoken": {
 					"type": "string",

--- a/schemas/dpi/digitalpost.schema.json
+++ b/schemas/dpi/digitalpost.schema.json
@@ -1,6 +1,6 @@
 {
 	"id": "https://docs.digdir.no/schemas/dpi/digitalpost.schema.json",
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "https://json-schema.org/draft-07/schema#",
 	"description": "Schema for Standard business document (SBD) brukt av Digdir",
 	"definitions": {
 		"standardBusinessDocument": {

--- a/schemas/dpi/digitalpost.schema.json
+++ b/schemas/dpi/digitalpost.schema.json
@@ -495,9 +495,9 @@
 			"description": "Informasjon relatert til presentasjon og behandling av en sikker digital post melding",
 			"$comment": "Dette er informasjon om den Digitalpostforsendelsen som vil bli brukt av Postkasseleverandør for å presentere og behandle den digitale posten. Den ikkeSensitiveTittelen vil bli brukt i dialogen med Innbygger dersom ikke Innbygger er autentisert på tilstrekkelig nivå. Den ikkeSensitiveTittelen vil også bli brukt i varsling til Innbygger. Når den digitale posten er dekryptert og innbygger er autentisert på tilstrekkelig sikkerhetsnivå så vil Tittel i Manifest-filen brukes.",
 			"properties": {
-				
-				"mottaker" : {"$ref": "#/definitions/adressseInfo"},
-				"utskriftstype": {"$ref": "#/definitions/utskriftstype"},				
+
+				"mottaker" : {"$ref": "#/definitions/adresseInformasjon"},
+				"utskriftstype": {"$ref": "#/definitions/utskriftstype"},
 				"retur" : { "$ref": "#/definitions/retur"},
 				"posttype": {"$ref": "#/definitions/posttype"}
 			},
@@ -521,7 +521,7 @@
 			"title": "retur",
 			"description": "Informasjon som brukes ved retur av post som av en eller annen grunn ikke kan levers til mottaker.",
 			"properties": {
-				"mottaker" : { "$ref": "#/definitions/adressseInfo"},
+				"mottaker" : { "$ref": "#/definitions/adresseInformasjon"},
 				"returposthaandtering": { "$ref": "#/definitions/returposthaandtering"}
 			},
 			"required": ["mottaker", "returposthaandtering"],
@@ -547,7 +547,7 @@
 		
 		"adresseInformasjon": {
 			"type": "object",
-			"$id": "#/definitions/adressseInfo",
+			"$id": "#/definitions/adresseInformasjon",
 			"additionalProperties": false,
 			"properties": {
 				"navn": {

--- a/schemas/dpi/dpi.schema.json
+++ b/schemas/dpi/dpi.schema.json
@@ -1,6 +1,6 @@
 {
 	"id": "https://docs.digdir.no/schemas/dpi/dpi.schema.json",
-	"$schema": "http://json-schema.org/draft-07/schema#",
+	"$schema": "https://json-schema.org/draft-07/schema#",
 	"description": "Schema for Standard business document (SBD) brukt av Digdir",
 	"definitions": {
 		"standardBusinessDocument": {

--- a/schemas/dpi/dpi.schema.json
+++ b/schemas/dpi/dpi.schema.json
@@ -1,5 +1,5 @@
 {
-	"id": "http://docs.digdir.no/schemas/dpi/dpi.schema.json",
+	"id": "https://docs.digdir.no/schemas/dpi/dpi.schema.json",
 	"$schema": "http://json-schema.org/draft-07/schema#",
 	"description": "Schema for Standard business document (SBD) brukt av Digdir",
 	"definitions": {
@@ -8,8 +8,8 @@
 			"additionalProperties": false,
 			"title": "standardBusinessDocument",
 			"properties": {
-				"standardBusinessDocumentHeader": { "$ref": "http://docs.digdir.no/schemas/common/sbdh.schema.json#/definitions/standardBusinessDocumentHeader"	},
-				"digitalpost" : {"$ref": "http://docs.digdir.no/schemas/dpi/digitalpost.schema.json#/definitions/digitalpost"}
+				"standardBusinessDocumentHeader": { "$ref": "https://docs.digdir.no/schemas/common/sbdh.schema.json#/definitions/standardBusinessDocumentHeader"	},
+				"digitalpost" : {"$ref": "https://docs.digdir.no/schemas/dpi/digitalpost.schema.json#/definitions/digitalpost"}
 			},
 			"required": [
 				"standardBusinessDocumentHeader", "digitalpost"

--- a/schemas/dpi/feil.schema.json
+++ b/schemas/dpi/feil.schema.json
@@ -1,6 +1,6 @@
 {
     "id": "https://docs.digdir.no/schemas/dpi/feil.schema.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "description": "En feilmelding fra postkasseleverandør med informasjon om en forretningsfeil knyttet til en digital post forsendelse.",
     "$comment": "Feilmelding sendes fra Postkasseleverandør når det oppstår en uventet feil som ikke kan håndteres av postkasseleverandør innenfor SLA krav. Feilene kategoriseres overordnet i to typer, enten som klient feil som Avsender må rette opp i eller som server feil som oppstår hos postkasseleverandør.",
     "definitions": {

--- a/schemas/dpi/feil.schema.json
+++ b/schemas/dpi/feil.schema.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://docs.digdir.no/schemas/dpi/feil.schema.json",
+    "id": "https://docs.digdir.no/schemas/dpi/feil.schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "En feilmelding fra postkasseleverandør med informasjon om en forretningsfeil knyttet til en digital post forsendelse.",
     "$comment": "Feilmelding sendes fra Postkasseleverandør når det oppstår en uventet feil som ikke kan håndteres av postkasseleverandør innenfor SLA krav. Feilene kategoriseres overordnet i to typer, enten som klient feil som Avsender må rette opp i eller som server feil som oppstår hos postkasseleverandør.",
@@ -10,16 +10,16 @@
             "title": "feil",
             "properties": {
                 "avsender": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/avsender"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/avsender"
                 },
                 "mottaker": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/virksomhetmottaker"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/virksomhetmottaker"
                 },
                 "maskinportentoken": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/maskinportentoken"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/maskinportentoken"
                 },
                 "tidspunkt": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/tidspunkt"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/tidspunkt"
                 },
                 "feiltype": {
                     "type": "string",

--- a/schemas/dpi/flyttedigitalpost.schema.json
+++ b/schemas/dpi/flyttedigitalpost.schema.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://docs.digdir.no/schemas/dpi/flyttedigitalpost.schema.json",
+    "id": "https://docs.digdir.no/schemas/dpi/flyttedigitalpost.schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "Kvittering på at postkassen eller utskriftstjenesten har tatt ansvar for å tilgjengeliggjøre melding til mottaker. Sendes til Avsender via meldingsformideler.",
     "$comment": "Denne kvitteringen kan Behandlingsansvarlig oppbevare som en garanti på at posten vil bli levert til Mottaker.",
@@ -10,23 +10,23 @@
             "title": "kvittering",
             "properties": {
                 "avsender": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/avsender"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/avsender"
                 },
                 "mottaker": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/personmottaker"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/personmottaker"
                 },
                 "maskinportentoken": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/maskinportentoken"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/maskinportentoken"
                 },
                 "tidspunkt": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/tidspunkt"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/tidspunkt"
                 },
                 "dokumentpakkefingeravtrykk":{
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/dokumentpakkefingeravtrykk"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/dokumentpakkefingeravtrykk"
                 },
                 "mottakstidspunkt": {"type": "string", "format": "date"},
                 "aapnet" : {"type": "boolean"},
-                "digitalpostinfo" : {"$ref": "http://docs.digdir.no/schemas/dpi/digitalpost.schema.json#/definitions/digitalpostinfo"}
+                "digitalpostinfo" : {"$ref": "https://docs.digdir.no/schemas/dpi/digitalpost.schema.json#/definitions/digitalpostinfo"}
             },
             "required": [
                 "avsender",

--- a/schemas/dpi/flyttedigitalpost.schema.json
+++ b/schemas/dpi/flyttedigitalpost.schema.json
@@ -1,6 +1,6 @@
 {
     "id": "https://docs.digdir.no/schemas/dpi/flyttedigitalpost.schema.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "description": "Kvittering på at postkassen eller utskriftstjenesten har tatt ansvar for å tilgjengeliggjøre melding til mottaker. Sendes til Avsender via meldingsformideler.",
     "$comment": "Denne kvitteringen kan Behandlingsansvarlig oppbevare som en garanti på at posten vil bli levert til Mottaker.",
     "definitions": {

--- a/schemas/dpi/leveringskvittering.schema.json
+++ b/schemas/dpi/leveringskvittering.schema.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://docs.digdir.no/schemas/dpi/leveringskvittering.schema.json",
+    "id": "https://docs.digdir.no/schemas/dpi/leveringskvittering.schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "Kvittering på at postkassen eller utskriftstjenesten har tatt ansvar for å tilgjengeliggjøre melding til mottaker. Sendes til Avsender via meldingsformideler.",
     "$comment": "Denne kvitteringen kan Behandlingsansvarlig oppbevare som en garanti på at posten vil bli levert til Mottaker.",
@@ -10,16 +10,16 @@
             "title": "kvittering",
             "properties": {
                 "avsender": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/avsender"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/avsender"
                 },
                 "mottaker": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/virksomhetmottaker"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/virksomhetmottaker"
                 },
                 "maskinportentoken": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/maskinportentoken"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/maskinportentoken"
                 },
                 "tidspunkt": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/tidspunkt"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/tidspunkt"
                 }
             },
             "required": [

--- a/schemas/dpi/leveringskvittering.schema.json
+++ b/schemas/dpi/leveringskvittering.schema.json
@@ -1,6 +1,6 @@
 {
     "id": "https://docs.digdir.no/schemas/dpi/leveringskvittering.schema.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "description": "Kvittering på at postkassen eller utskriftstjenesten har tatt ansvar for å tilgjengeliggjøre melding til mottaker. Sendes til Avsender via meldingsformideler.",
     "$comment": "Denne kvitteringen kan Behandlingsansvarlig oppbevare som en garanti på at posten vil bli levert til Mottaker.",
     "definitions": {

--- a/schemas/dpi/mottakskvittering.schema.json
+++ b/schemas/dpi/mottakskvittering.schema.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://docs.digdir.no/schemas/dpi/mottakskvittering.schema.json",
+    "id": "https://docs.digdir.no/schemas/dpi/mottakskvittering.schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "En Kvitteringsmelding til Avsender om at utskrift og forsendelsestjenesten har mottatt forsendelsen og har lagt den klar for utskrift.",
     "$comment": "Denne Kvitteringen leveres tilbake så fort utskrift og forsendelsestjenesten har mottatt forsendelsen og validert at den kan skrives ut. Forsendelsen vil så legges i kø og tas med i neste utskriftsjobb for denne type post.",
@@ -10,16 +10,16 @@
             "title": "kvittering",
             "properties": {
                 "avsender": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/avsender"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/avsender"
                 },
                 "mottaker": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/virksomhetmottaker"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/virksomhetmottaker"
                 },
                 "maskinportentoken": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/maskinportentoken"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/maskinportentoken"
                 },
                 "tidspunkt": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/tidspunkt"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/tidspunkt"
                 }
             },
             "required": [

--- a/schemas/dpi/mottakskvittering.schema.json
+++ b/schemas/dpi/mottakskvittering.schema.json
@@ -1,6 +1,6 @@
 {
     "id": "https://docs.digdir.no/schemas/dpi/mottakskvittering.schema.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "description": "En Kvitteringsmelding til Avsender om at utskrift og forsendelsestjenesten har mottatt forsendelsen og har lagt den klar for utskrift.",
     "$comment": "Denne Kvitteringen leveres tilbake så fort utskrift og forsendelsestjenesten har mottatt forsendelsen og validert at den kan skrives ut. Forsendelsen vil så legges i kø og tas med i neste utskriftsjobb for denne type post.",
     "definitions": {

--- a/schemas/dpi/returpostkvittering.schema.json
+++ b/schemas/dpi/returpostkvittering.schema.json
@@ -1,6 +1,6 @@
 {
     "id": "https://docs.digdir.no/schemas/dpi/returpostkvittering.schema.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "description": "En Kvitteringsmelding fra Utskriftstjenesten til Avsender om at post ikke kunne leveres til Mottaker.",
     "$comment": "Dette er Kvittering på at posten har kommet i retur og har blitt makulert.",
     "definitions": {

--- a/schemas/dpi/returpostkvittering.schema.json
+++ b/schemas/dpi/returpostkvittering.schema.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://docs.digdir.no/schemas/dpi/returpostkvittering.schema.json",
+    "id": "https://docs.digdir.no/schemas/dpi/returpostkvittering.schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "En Kvitteringsmelding fra Utskriftstjenesten til Avsender om at post ikke kunne leveres til Mottaker.",
     "$comment": "Dette er Kvittering på at posten har kommet i retur og har blitt makulert.",
@@ -10,16 +10,16 @@
             "title": "kvittering",
             "properties": {
                 "avsender": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/avsender"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/avsender"
                 },
                 "mottaker": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/virksomhetmottaker"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/virksomhetmottaker"
                 },
                 "maskinportentoken": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/maskinportentoken"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/maskinportentoken"
                 },
                 "tidspunkt": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/tidspunkt"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/tidspunkt"
                 }
             },
             "required": [

--- a/schemas/dpi/varslingfeiletkvittering.schema.json
+++ b/schemas/dpi/varslingfeiletkvittering.schema.json
@@ -1,5 +1,5 @@
 {
-    "id": "http://docs.digdir.no/schemas/dpi/varslingfeiletkvittering.schema.json",
+    "id": "https://docs.digdir.no/schemas/dpi/varslingfeiletkvittering.schema.json",
     "$schema": "http://json-schema.org/draft-07/schema#",
     "description": "En Kvitteringsmelding til Avsender om at varsling til Mottaker har feilet og dermed ikke har blitt utført som forutsatt.",
     "$comment": "Dersom Postkasse opplever problemer med å utføre varslingen som spesifisert i meldingen, skal Postkasse informere Avsender om dette ved å sende VarslingfeiletKvittering. Det skal sendes en kvittering for hver forekomst av en feilsituasjon i en spesifisert kanal. Meldinger som angir bruk av flere varslingskanaler kan dermed medføre flere VarslingfeiletKvitteringer. Varslingfeilet kvittering skal sendes seinest dagen etter at varslingen var bestilt.",
@@ -10,16 +10,16 @@
             "title": "kvittering",
             "properties": {
                 "avsender": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/avsender"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/avsender"
                 },
                 "mottaker": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/virksomhetmottaker"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/virksomhetmottaker"
                 },
                 "maskinportentoken": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/maskinportentoken"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/maskinportentoken"
                 },
                 "tidspunkt": {
-                    "$ref": "http://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/tidspunkt"
+                    "$ref": "https://docs.digdir.no/schemas/dpi/commons.schema.json#/definitions/tidspunkt"
                 },
                 "beskrivelse": {
                     "type": "string",

--- a/schemas/dpi/varslingfeiletkvittering.schema.json
+++ b/schemas/dpi/varslingfeiletkvittering.schema.json
@@ -1,6 +1,6 @@
 {
     "id": "https://docs.digdir.no/schemas/dpi/varslingfeiletkvittering.schema.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "description": "En Kvitteringsmelding til Avsender om at varsling til Mottaker har feilet og dermed ikke har blitt utført som forutsatt.",
     "$comment": "Dersom Postkasse opplever problemer med å utføre varslingen som spesifisert i meldingen, skal Postkasse informere Avsender om dette ved å sende VarslingfeiletKvittering. Det skal sendes en kvittering for hver forekomst av en feilsituasjon i en spesifisert kanal. Meldinger som angir bruk av flere varslingskanaler kan dermed medføre flere VarslingfeiletKvitteringer. Varslingfeilet kvittering skal sendes seinest dagen etter at varslingen var bestilt.",
     "definitions": {


### PR DESCRIPTION
Bakgrunn: Jeg opplevde noen problemer med kodegenereringsverktøy (https://github.com/joelittlejohn/jsonschema2pojo) ved bruk av disse schemaene.

Denne PR-en fikser problemene jeg støtte på (http mot bruk dos.digdir og addresseInfo-feltet). Jeg anbefaler å se på commit for commit.

bonus: endrer fra http -> https for `$schema`-feltet