### PR TITLE
Sdp nyinf: Fjern språk-felt fra smsvarsel og epostvarsel

### DIFF
--- a/resources/begrep/sikkerDigitalPost/nyinf/eksempler/digitalpost_dpi_1_0_sample.json
+++ b/resources/begrep/sikkerDigitalPost/nyinf/eksempler/digitalpost_dpi_1_0_sample.json
@@ -58,13 +58,11 @@
                     "epostvarsel":{
                         "epostadresse" : "test@epost.no",
                         "varslingstekst" : "Dette er en varslingstekst",
-                        "spraak": "NO",
                         "repetisjoner" : [1,7]
                     },
                     "smsvarsel":{
                         "mobiltelefonnummer" : "12345678",
                         "varslingstekst" : "Dette er en varslingstekst",
-                        "spraak": "NO",
                         "repetisjoner" : [1,7]
                     }                    
                 }                             

--- a/resources/begrep/sikkerDigitalPost/nyinf/eksempler/innbyggerpost_dpi_1_0_budnad2_sample.json
+++ b/resources/begrep/sikkerDigitalPost/nyinf/eksempler/innbyggerpost_dpi_1_0_budnad2_sample.json
@@ -62,7 +62,6 @@
                 "epostvarsel": {
                     "epostadresse": "test@epost.no",
                     "varslingstekst": "Dette er en varslingstekst",
-                    "spraak": "NO",
                     "repetisjoner": [
                         1,
                         7
@@ -71,7 +70,6 @@
                 "smsvarsel": {
                     "mobiltelefonnummer": "12345678",
                     "varslingstekst": "Dette er en varslingstekst",
-                    "spraak": "NO",
                     "repetisjoner": [
                         1,
                         7

--- a/resources/begrep/sikkerDigitalPost/nyinf/eksempler/innbyggerpost_dpi_1_0_budnad_sample.json
+++ b/resources/begrep/sikkerDigitalPost/nyinf/eksempler/innbyggerpost_dpi_1_0_budnad_sample.json
@@ -55,13 +55,11 @@
                 "epostvarsel":{
                     "epostadresse" : "test@epost.no",
                     "varslingstekst" : "Dette er en varslingstekst",
-                    "spraak": "NO",
                     "repetisjoner" : [1,7]
                 },
                 "smsvarsel":{
                     "mobiltelefonnummer" : "12345678",
                     "varslingstekst" : "Dette er en varslingstekst",
-                    "spraak": "NO",
                     "repetisjoner" : [1,7]
                 }                    
             }, 

--- a/resources/begrep/sikkerDigitalPost/nyinf/eksempler/innbyggerpost_dpi_1_0_nav_sample.json
+++ b/resources/begrep/sikkerDigitalPost/nyinf/eksempler/innbyggerpost_dpi_1_0_nav_sample.json
@@ -61,7 +61,6 @@
                 "epostvarsel": {
                     "epostadresse": "test@epost.no",
                     "varslingstekst": "Dette er en varslingstekst",
-                    "spraak": "NO",
                     "repetisjoner": [
                         1,
                         7
@@ -70,7 +69,6 @@
                 "smsvarsel": {
                     "mobiltelefonnummer": "12345678",
                     "varslingstekst": "Dette er en varslingstekst",
-                    "spraak": "NO",
                     "repetisjoner": [
                         1,
                         7

--- a/resources/begrep/sikkerDigitalPost/nyinf/eksempler/innbyggerpost_dpi_digital_1_0.json
+++ b/resources/begrep/sikkerDigitalPost/nyinf/eksempler/innbyggerpost_dpi_digital_1_0.json
@@ -61,7 +61,6 @@
                 "epostvarsel": {
                     "epostadresse": "test@epost.no",
                     "varslingstekst": "Dette er en varslingstekst",
-                    "spraak": "NO",
                     "repetisjoner": [
                         1,
                         7
@@ -70,7 +69,6 @@
                 "smsvarsel": {
                     "mobiltelefonnummer": "12345678",
                     "varslingstekst": "Dette er en varslingstekst",
-                    "spraak": "NO",
                     "repetisjoner": [
                         1,
                         7

--- a/schemas/dpi/commons.schema.json
+++ b/schemas/dpi/commons.schema.json
@@ -281,9 +281,6 @@
                     "minLength": 1,
                     "maxLength": 500
                 },
-                "spraak": {
-                    "$ref": "#/definitions/spraak"
-                },
                 "repetisjoner": {
                     "$ref": "#/definitions/repetisjoner"
                 }
@@ -291,8 +288,7 @@
             "required": [
                 "epostadresse",
                 "varslingstekst",
-                "repetisjoner",
-                "spraak"
+                "repetisjoner"
             ]
         },
         "repetisjoner": {
@@ -345,9 +341,6 @@
                     "minLength": 1,
                     "maxLength": 160
                 },
-                "spraak": {
-                    "$ref": "#/definitions/spraak"
-                },
                 "repetisjoner": {
                     "$ref": "#/definitions/repetisjoner"
                 }
@@ -355,7 +348,6 @@
             "required": [
                 "mobiltelefonnummer",
                 "varslingstekst",
-                "spraak",
                 "repetisjoner"
             ],
             "additionalProperties": false


### PR DESCRIPTION
Det å sette språk på smsvarsel og epostvarsel gir ikke noe ekstra funksjonalitet selv om det er lov i dagens spec for dpi.
Språk fra ikkesensitivtittel kan benyttes for å spesifisere språk. Dette feltet er også required, slik at man er garantert at språk-informasjon er tilgjengelig.

Oppdatert eksempler.