### PR TITLE
Oppdater sdp schema

### DIFF
--- a/resources/begrep/sikkerDigitalPost/xsd/sdp-felles.xsd
+++ b/resources/begrep/sikkerDigitalPost/xsd/sdp-felles.xsd
@@ -49,7 +49,7 @@
 
 	<xsd:complexType name="Person">
 		<xsd:sequence>
-			<xsd:element name="personidentifikator" minOccurs="1" maxOccurs="1">
+			<xsd:element name="personidentifikator" minOccurs="0" maxOccurs="1">
 				<xsd:simpleType>
 					<xsd:restriction base="xsd:string">
 						<xsd:pattern value="[0-9]{11}"/>

--- a/resources/begrep/sikkerDigitalPost/xsd/sdp-melding.xsd
+++ b/resources/begrep/sikkerDigitalPost/xsd/sdp-melding.xsd
@@ -109,6 +109,7 @@
 				</xsd:annotation>
 			</xsd:element>
 			<xsd:element name="varsler" type="Varsler" minOccurs="0" maxOccurs="1"/>
+			<xsd:element name="maskinportentoken" type="xsd:string" minOccurs="0" maxOccurs="1"/>
 		</xsd:sequence>
 	</xsd:complexType>
 
@@ -226,6 +227,7 @@
 					</xsd:documentation>
 				</xsd:annotation>
 			</xsd:element>
+            <xsd:element name="maskinportentoken" type="xsd:string" minOccurs="0" maxOccurs="1"/>
 		</xsd:sequence>
 	</xsd:complexType>
 


### PR DESCRIPTION
- **Personidentifikator ikke påkrevet i foretningsmelding:**
    I forbindelse med dpi over peppol-arbeidet ble det besluttet at personidentifikator fjernes fra forretningsmeldingen. Mellom c2 og c3 er dette fjernet i jsonschema.
    Denne endringen reflekterer endringen i xsd-schema brukt mellom c3 og c4. For å ikke bryte bakoverkompabilitet settes personidentifikator til minOccurs=0 for Person.

-  **Legger til maskinportentoken for digital og fysisk post:**
    Forberedelse til kommende EA fra digdir der postkasseleverandørene skal validere maskinportentoken ifbm dpi over peppol-nettverket.
    Setter minOccurs til 0 for å bevare bakoverkompabilitet
