### PR TITLE
Legger til ny asic-xsd med samme innehold, men annet namespace

### DIFF
--- a/resources/begrep/sikkerDigitalPost/xsd/asic-e/ts_102918v010201_2.xsd
+++ b/resources/begrep/sikkerDigitalPost/xsd/asic-e/ts_102918v010201_2.xsd
@@ -1,0 +1,65 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<xsd:schema targetNamespace="http://uri.etsi.org/02918/v1.2.1#"
+	xmlns:ds="http://www.w3.org/2000/09/xmldsig#" xmlns="http://uri.etsi.org/02918/v1.2.1#"
+	xmlns:xsd="http://www.w3.org/2001/XMLSchema" elementFormDefault="qualified"
+	attributeFormDefault="unqualified">
+	<xsd:import namespace="http://www.w3.org/2000/09/xmldsig#"
+		schemaLocation="../w3/xmldsig-core-schema.xsd"/>
+	<xsd:element name="ASiCManifest" type="ASiCManifestType">
+		<xsd:annotation>
+			<xsd:documentation>Schema for ASiC-E with CAdES specifying content for ASiCManifest.xml</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="ASiCManifestType">
+		<xsd:sequence>
+			<xsd:element ref="SigReference"/>
+			<xsd:element ref="DataObjectReference" maxOccurs="unbounded"/>
+			<xsd:element name="ASiCManifestExtensions" type="ExtensionsListType" minOccurs="0"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="SigReference" type="SigReferenceType"/>
+	<xsd:complexType name="SigReferenceType">
+		<xsd:attribute name="URI" type="xsd:anyURI" use="required"/>
+		<xsd:attribute name="MimeType" type="xsd:string" use="optional"/>
+	</xsd:complexType>
+	<xsd:element name="DataObjectReference" type="DataObjectReferenceType"/>
+	<xsd:complexType name="DataObjectReferenceType">
+		<xsd:sequence>
+			<xsd:element ref="ds:DigestMethod"/>
+			<xsd:element ref="ds:DigestValue"/>
+			<xsd:element name="DataObjectReferenceExtensions" type="ExtensionsListType"
+				minOccurs="0"/>
+		</xsd:sequence>
+		<xsd:attribute name="URI" type="xsd:anyURI" use="required"/>
+		<xsd:attribute name="MimeType" type="xsd:string" use="optional"/>
+		<xsd:attribute name="Rootfile" type="xsd:boolean" use="optional"/>
+	</xsd:complexType>
+	<xsd:complexType name="AnyType" mixed="true">
+		<xsd:sequence minOccurs="0" maxOccurs="unbounded">
+			<xsd:any processContents="lax"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="Extension" type="ExtensionType"/>
+	<xsd:complexType name="ExtensionType">
+		<xsd:complexContent>
+			<xsd:extension base="AnyType">
+				<xsd:attribute name="Critical" type="xsd:boolean" use="required"/>
+			</xsd:extension>
+		</xsd:complexContent>
+	</xsd:complexType>
+	<xsd:complexType name="ExtensionsListType">
+		<xsd:sequence>
+			<xsd:element ref="Extension" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+	<xsd:element name="XAdESSignatures" type="XAdESSignaturesType">
+		<xsd:annotation>
+			<xsd:documentation>Schema for ASiC-E with XAdES to include one or more XML signatures in *signatures*.xml</xsd:documentation>
+		</xsd:annotation>
+	</xsd:element>
+	<xsd:complexType name="XAdESSignaturesType">
+		<xsd:sequence>
+			<xsd:element ref="ds:Signature" maxOccurs="unbounded"/>
+		</xsd:sequence>
+	</xsd:complexType>
+</xsd:schema>


### PR DESCRIPTION
Etter Digdir tok i bruk nytt bibliotek for generering av dokumentpakker, er Meldingsformidler nødt til å behandle to ulike namespaces i parallell. Vi er derfor avhengig av at begge disse filene eksisterer:
- ts_102918v010201.xsd (med namespace "http://uri.etsi.org/2918/v1.2.1#")
- ts_102918v010201_2.xsd (med namespace "http://uri.etsi.org/02918/v1.2.1#")