### PR TITLE
Oppdatere krr_attributter - presisere docs på felt.

### DIFF
--- a/_docs/Kontaktregisteret/krr_attributter.md
+++ b/_docs/Kontaktregisteret/krr_attributter.md
@@ -14,19 +14,19 @@ Her er en oversikt over attributtene som finnes i KRR sitt REST API og hvilken r
 | Attributtnavn | Beskrivelse | Mulige responser |
 | - | - | - |
 | personidentifikator | Gyldig fødselsnummer eller D-nummer | 01048800153 |
-| reservasjon | Reservasjon avgitt av Innbygger, brukt i henhold til eForvaltningsforskriften § 15 a. | JA, NEI |
+| reservasjon | Reservasjon avgitt av bruker, brukt i henhold til eForvaltningsforskriften § 15 a. | JA, NEI |
 | status | Angir status for brukeren | AKTIV, SLETTET, IKKE_REGISTRERT |
 | varslingsstatus | Tekstlig beskrivelse om bruker kan varsles eller ikke | KAN_VARSLES, KAN_IKKE_VARSLES |
-| epostadresse | Epostadressen som innbygger har registrert i KRR | Eks. 01012295312_test@minid.difi.no |
-| epostadresse_oppdatert | Sist gang epostadressen ble oppdatert | Angis som dato og klokkeslett |
-| epostadresse_sist_verifisert | Sist gang epostadressen ble verifisert | Angis som dato og klokkeslett |
-| mobiltelefonnummer | Mobilnummer som innbygger har registrert i KRR | Mobilnummer |
-| mobiltelefonnummer_oppdatert | Sist gang mobilnummer ble oppdatert | Angis som dato og klokkeslett |
-| mobiltelefonnummer_sist_verifisert | Sist gang mobilnummer ble verifisert | Angis som dato og klokkeslett |
+| epostadresse | Epostadressen som bruker har registrert i KRR | Eks. 01012295312_test@minid.difi.no |
+| epostadresse_oppdatert | Sist gang epostadresse ble oppdatert av bruker. Ny eller endret epostadresse. Dato kan være mer enn 18 måneder tilbake i tid. | Eks. 2016-08-05T10:45:15.768Z |
+| epostadresse_sist_verifisert | Sist gang epostadresse ble verifisert av bruker. Bekreftes av bruker minst to ganger i året. | Eks. 2022-08-05T10:45:15.768Z |
+| mobiltelefonnummer | Mobilnummer som bruker har registrert i KRR | Mobilnummer |
+| mobiltelefonnummer_oppdatert | Sist gang mobiltelefonnummer ble oppdatert av bruker.  Nytt eller endret mobilnummer. Dato kan være mer enn 18 måneder tilbake i tid. | Eks. 2016-08-05T10:45:15.768Z |
+| mobiltelefonnummer_sist_verifisert | Sist gang mobiltelefonnummer ble verifisert av bruker.  Bekreftes av bruker minst to ganger i året.| Eks. 2022-08-05T10:45:15.768Z |
 | postkasseadresse | Unik adresse for en person sin postkasseadresse hos en postkasseleverandør. | Eks. ola.nordmann#9YDT |
 | postkasseleverandoeradresse | Org.nummer til postkasseleverandør | 984661185, 922020175 |
 | sertifikat | personsertifikat for Digital Post | X509Certificate |
 | spraak | Bruker sitt foretrukne språk for kommunikasjon med det offentlige | nn, nb, en, se |
-| spraak_oppdatert | Sist gang språkvalg ble oppdatert | Angis som dato og klokkeslett |
+| spraak_oppdatert | Sist gang språkvalg ble oppdatert | Eks. 2022-08-05T10:45:15.768Z |
 
 Du kan finne et utvalg testbrukere på siden [Testbrukere i KRR]({{site.baseurl}}/docs/Kontaktregisteret/krr_testbrukere)

--- a/_docs/Kontaktregisteret/krr_attributter.md
+++ b/_docs/Kontaktregisteret/krr_attributter.md
@@ -14,19 +14,19 @@ Her er en oversikt over attributtene som finnes i KRR sitt REST API og hvilken r
 | Attributtnavn | Beskrivelse | Mulige responser |
 | - | - | - |
 | personidentifikator | Gyldig fødselsnummer eller D-nummer | 01048800153 |
-| reservasjon | Reservasjon avgitt av bruker, brukt i henhold til eForvaltningsforskriften § 15 a. | JA, NEI |
-| status | Angir status for brukeren | AKTIV, SLETTET, IKKE_REGISTRERT |
-| varslingsstatus | Tekstlig beskrivelse om bruker kan varsles eller ikke | KAN_VARSLES, KAN_IKKE_VARSLES |
-| epostadresse | Epostadressen som bruker har registrert i KRR | Eks. 01012295312_test@minid.difi.no |
-| epostadresse_oppdatert | Sist gang epostadresse ble oppdatert av bruker. Ny eller endret epostadresse. Dato kan være mer enn 18 måneder tilbake i tid. | Eks. 2016-08-05T10:45:15.768Z |
-| epostadresse_sist_verifisert | Sist gang epostadresse ble verifisert av bruker. Bekreftes av bruker minst to ganger i året. | Eks. 2022-08-05T10:45:15.768Z |
-| mobiltelefonnummer | Mobilnummer som bruker har registrert i KRR | Mobilnummer |
-| mobiltelefonnummer_oppdatert | Sist gang mobiltelefonnummer ble oppdatert av bruker.  Nytt eller endret mobilnummer. Dato kan være mer enn 18 måneder tilbake i tid. | Eks. 2016-08-05T10:45:15.768Z |
-| mobiltelefonnummer_sist_verifisert | Sist gang mobiltelefonnummer ble verifisert av bruker.  Bekreftes av bruker minst to ganger i året.| Eks. 2022-08-05T10:45:15.768Z |
+| reservasjon | Reservasjon avgitt av person, brukt i henhold til eForvaltningsforskriften § 15 a. | JA, NEI |
+| status | Angir status for personen | AKTIV, SLETTET, IKKE_REGISTRERT |
+| varslingsstatus | Tekstlig beskrivelse om person kan varsles eller ikke | KAN_VARSLES, KAN_IKKE_VARSLES |
+| epostadresse | Epostadressen som person har registrert i KRR | Eks. 01012295312_test@minid.difi.no |
+| epostadresse_oppdatert | Sist gang epostadresse ble oppdatert av person. Ny eller endret epostadresse. Dato kan være mer enn 18 måneder tilbake i tid. | Eks. 2016-08-05T10:45:15.768Z |
+| epostadresse_sist_verifisert | Sist gang epostadresse ble verifisert av person. Bekreftes av person minst to ganger i året. | Eks. 2022-08-05T10:45:15.768Z |
+| mobiltelefonnummer | Mobilnummer som person har registrert i KRR | Mobilnummer |
+| mobiltelefonnummer_oppdatert | Sist gang mobiltelefonnummer ble oppdatert av person.  Nytt eller endret mobilnummer. Dato kan være mer enn 18 måneder tilbake i tid. | Eks. 2016-08-05T10:45:15.768Z |
+| mobiltelefonnummer_sist_verifisert | Sist gang mobiltelefonnummer ble verifisert av person.  Bekreftes av person minst to ganger i året.| Eks. 2022-08-05T10:45:15.768Z |
 | postkasseadresse | Unik adresse for en person sin postkasseadresse hos en postkasseleverandør. | Eks. ola.nordmann#9YDT |
 | postkasseleverandoeradresse | Org.nummer til postkasseleverandør | 984661185, 922020175 |
 | sertifikat | personsertifikat for Digital Post | X509Certificate |
-| spraak | Bruker sitt foretrukne språk for kommunikasjon med det offentlige | nn, nb, en, se |
+| spraak | Personen sitt foretrukne språk for kommunikasjon med det offentlige | nn, nb, en, se |
 | spraak_oppdatert | Sist gang språkvalg ble oppdatert | Eks. 2022-08-05T10:45:15.768Z |
 
 Du kan finne et utvalg testbrukere på siden [Testbrukere i KRR]({{site.baseurl}}/docs/Kontaktregisteret/krr_testbrukere)


### PR DESCRIPTION
Hei, vi er et team på NAV som er flittige brukere av KRR. Vi ønsker å få noen forbedrede beskrivelser på feltene til KRR tjenesten, for å unngå misforståelser.

Fint om dere kan kvalitetssikre. Testet OK lokalt med jekyll

* Presiserte beskrivelse av _oppdatert feltene for epostadresse og mobiltelefonnummer.
* Presiserte beskrivelse av _sist_verifisert feltene for epostadresse og mobiltelefonnummer.
* Inkluderte dato og tid som konkret eksempel for _oppdatert og _sist_verifisert for epostadresse og mobiltelefonnummer.
* Inkluderte dato og tid som konkret eksempel for spraak_oppdatert.
* Endret bruk av begrep fra innbygger til bruker.