### PR TITLE
Endre forskriftsreferanse for begrep "reservasjon"

### DIFF
--- a/resources/begrep/sikkerDigitalPost/begrep/reservasjon.md
+++ b/resources/begrep/sikkerDigitalPost/begrep/reservasjon.md
@@ -10,7 +10,7 @@ redirect_from: /reservasjon
 | Definisjon | avgitt Forbehold i henhold til eForvaltningsforskriften |
 | Datatype | string |
 | Kilde | DIFI |
-| Kommentar | Reservasjon avgitt av Innbygger, brukt i henhold til eForvaltningsforskriften § 15 a. | 
+| Kommentar | Reservasjon avgitt av Innbygger, brukt i henhold til eForvaltningsforskriften § 9. | 
 | Gyldige verdier | JA ; NEI |
 | Standardverdi | NEI |
 


### PR DESCRIPTION
Definisjonen for begrepet "reservasjon" viser til feil forskriftsparagraf i eForv.f. Riktig paragraf ("Reservasjon") skal vere § 9.