### PR TITLE
Ikke bruk flagget -i når curl skriver til en fil

### DIFF
--- a/_docs/eFormidling/Selvhjelp/sporsmal_og_svar.md
+++ b/_docs/eFormidling/Selvhjelp/sporsmal_og_svar.md
@@ -190,7 +190,7 @@ Etter oppgraderinger kan det skje at det blir liggande igjen gamle kvitteringer 
 For å manuelt laste ned en innkommende melding fra integrasjonspunktet trenger du en HTTP-klient med GUI (for eksempel Postman) eller en kommandolinje/terminal som støtter kommandoen `curl`.
 
 1. Lås meldingen: `curl 'http://localhost:9093/api/messages/in/peek/?messageID=2f553592-1ebc-4b56-b5bd-73479300fe8c' -i -X GET`
-2. Last ned meldingen: `curl 'http://localhost:9093/api/messages/in/pop/2f553592-1ebc-4b56-b5bd-73479300fe8c' -i -X GET > asic.zip`
+2. Last ned meldingen: `curl 'http://localhost:9093/api/messages/in/pop/2f553592-1ebc-4b56-b5bd-73479300fe8c' -X GET > asic.zip`
 3. EVENTUELT - marker meldingen som ferdig behandla: `curl 'http://localhost:9093/api/messages/in/2f553592-1ebc-4b56-b5bd-73479300fe8c' -i -X DELETE`
 
 ### Hvordan migrerer jeg data fra den medfølgene H2-fildatabasen?


### PR DESCRIPTION
Fordi HTTP response headers da skrives til begynnelsen av filen.