### PR TITLE
Juster eFormidlings dokumentasjon til ny plattform

### DIFF
--- a/_data/eformidling_sidebar.yml
+++ b/_data/eformidling_sidebar.yml
@@ -99,8 +99,8 @@ folders:
   folderitems:
     - title: Produksjon
       jurl: /docs/eFormidling/Miljo/produksjon
-    - title: QA
-      jurl: /docs/eFormidling/Miljo/qa
+    - title: Test
+      jurl: /docs/eFormidling/Miljo/test
 
 ###########################
 

--- a/_docs/eFormidling/Miljo/produksjon.md
+++ b/_docs/eFormidling/Miljo/produksjon.md
@@ -12,16 +12,16 @@ For å bruke eFormidlings produksjonsmiljø kreves et virksomhetssertifikat.
 
 Integrasjonspunktet benytter produksjonsmiljøet som standard:
 
-- [Konfigurasjon av miljø (produksjon eller QA)](../installasjon/installasjon#miljø-produksjon-eller-qa)
+- [Konfigurasjon av miljø (produksjon eller test)](../installasjon/installasjon#miljø-produksjon-eller-test)
 
 Følgende tjenester brukes av integrasjonspunktets produksjonsmiljø og må kunne nås:
 
 | DNS-navn                            | IPv4-adresse                                        | Port | Tjeneste | Beskrivelse                                                                              | Inn-/utgående trafikk |
 |-------------------------------------|-----------------------------------------------------|------|----------|------------------------------------------------------------------------------------------|-----------------------|
-| meldingsutveksling.difi.no          | 51.144.60.163                                       | 443  | Alle     | eFormidling, diverse tjenester, adresseoppslag m.m.                                      | utgående              |
-| eformidling.no (ny plattform)                      | 139.105.36.173                                      | 443  | Alle     | eFormidling, diverse tjenester, adresseoppslag m.m.                                      | utgående              |
-| logs.eformidling.no (ny plattform)                      | 139.105.36.177                                     | 443  | Alle     | eFormidling, logging                                     | utgående              |
-| stream-meldingsutveksling.difi.no   | 40.74.39.254                                        | 443  | Alle     | eFormidling, logging                                                                     | utgående              |
+| meldingsutveksling.difi.no (fases ut)         | 139.105.36.173                                       | 443  | Alle     | eFormidling, diverse tjenester, adresseoppslag m.m.                                      | utgående              |
+| eformidling.no                      | 139.105.36.173                                      | 443  | Alle     | eFormidling, diverse tjenester, adresseoppslag m.m.                                      | utgående              |
+| logs.eformidling.no                       | 139.105.36.177                                     | 443  | Alle     | eFormidling, logging                                     | utgående              |
+| stream-meldingsutveksling.difi.no (fases ut)  | 139.105.36.177                                        | 443  | Alle     | eFormidling, logging                                                                     | utgående              |
 | maskinporten.no                     | 139.105.36.164                                      | 443  | Alle     | Maskinporten                                                                             | utgående              |
 | efm-dpe-prod.servicebus.windows.net | 13.74.107.66 <br/> 13.69.227.68 <br/> 52.138.226.67 <br/> 20.82.244.139 | 443  | DPE      | Azure Service Bus, HTTP/REST API                                                         | utgående              |
 | efm-dpe-prod.servicebus.windows.net | 13.74.107.66 <br/> 13.69.227.68 <br/> 52.138.226.67 <br/> 20.82.244.139 | 5671 | DPE      | Azure Service Bus, AMQP med TLS                                                          | utgående              |

--- a/_docs/eFormidling/Miljo/test.md
+++ b/_docs/eFormidling/Miljo/test.md
@@ -1,12 +1,12 @@
 ---
-title: QA
+title: Test
 description: ""
 summary: ""
 product: eFormidling
 sidebar: eformidling_sidebar
 ---
 
-Ved å bruke eFormidlings testmiljø (QA) når, og nås, integrasjonspunktet av test-virksomheter og test-innbyggere.
+Ved å bruke eFormidlings testmiljø når, og nås, integrasjonspunktet av test-virksomheter og test-innbyggere.
 
 Se mer om testing av eFormidling på:
 
@@ -16,16 +16,16 @@ For å bruke eFormidlings testmiljø kreves et test-virksomhetssertifikat utsted
 
 Integrasjonspunktet må konfigureres til å bruke testmiljøet:
 
-- [Konfigurasjon av miljø (produksjon eller QA)](../installasjon/installasjon#miljø-produksjon-eller-qa)
+- [Konfigurasjon av miljø (produksjon eller test)](../installasjon/installasjon#miljø-produksjon-eller-test)
 
-Følgende tjenester brukes av integrasjonspunktets QA-miljø og må kunne nås:
+Følgende tjenester brukes av integrasjonspunktets test-miljø og må kunne nås:
 
 | DNS-navn                                  | IPv4-adresse                                        | Port  | Tjeneste | Beskrivelse                                                                              | Inn-/utgående trafikk |
 |-------------------------------------------|-----------------------------------------------------|-------|----------|------------------------------------------------------------------------------------------|-----------------------|
-| qa-meldingsutveksling.difi.no             | 51.144.60.111 <br/> 51.105.206.80                   | 443   | Alle     | eFormidling, diverse tjenester, adresseoppslag m.m.                                      | utgående              |
-| test.eformidling.no (ny plattform)                      | 139.105.36.141                                      | 443  | Alle     | eFormidling, diverse tjenester, adresseoppslag m.m.                                      | utgående              |
-| test-logs.eformidling.no  (ny plattform)                      | 139.105.36.145                                     | 443  | Alle     | eFormidling, diverse tjenester, adresseoppslag m.m.                                      | utgående              |
-| qa-stream-meldingsutveksling.difi.no      | 40.74.39.255                                        | 443   | Alle     | eFormidling, logging                                                                     | utgående              |
+| qa-meldingsutveksling.difi.no (fases ut)            | 139.105.36.141                   | 443   | Alle     | eFormidling, diverse tjenester, adresseoppslag m.m.                                      | utgående              |
+| test.eformidling.no                       | 139.105.36.141                                      | 443  | Alle     | eFormidling, diverse tjenester, adresseoppslag m.m.                                      | utgående              |
+| test-logs.eformidling.no                       | 139.105.36.145                                     | 443  | Alle     | eFormidling, diverse tjenester, adresseoppslag m.m.                                      | utgående              |
+| qa-stream-meldingsutveksling.difi.no (fases ut)      | 139.105.36.145                                        | 443   | Alle     | eFormidling, logging                                                                     | utgående              |
 | test.maskinporten.no                      | 139.105.36.128/27 <br/> 139.105.36.132              | 443   | Alle     | Maskinporten                                                                             | utgående              |
 | efm-dpe-qa.servicebus.windows.net         | 13.74.107.66 <br/> 13.69.227.68 <br/> 52.138.226.67 <br/> 20.82.244.139 | 443   | DPE      | Azure Service Bus, HTTP/REST API                                                         | utgående              |
 | efm-dpe-qa.servicebus.windows.net         | 13.74.107.66 <br/> 13.69.227.68 <br/> 52.138.226.67 <br/> 20.82.244.139 | 5671  | DPE      | Azure Service Bus, AMQP med TLS                                                          | utgående              |

--- a/_docs/eFormidling/Selvhjelp/kjente_feil.md
+++ b/_docs/eFormidling/Selvhjelp/kjente_feil.md
@@ -257,7 +257,7 @@ Denne feilen kan forekomme når ein ikkje har satt propertien:
 difi.move.dpi.receipt-type=xmlsoap
 og eller ein manglar brannmur åpning mot buypass:  
 [Prod miljøet](https://docs.digdir.no/docs/eFormidling/Miljo/produksjon)  
-[QA miljøet](https://docs.digdir.no/docs/eFormidling/Miljo/qa) 
+[Test miljøet](https://docs.digdir.no/docs/eFormidling/Miljo/test) 
 
  
 

--- a/_docs/eFormidling/Testing/index.md
+++ b/_docs/eFormidling/Testing/index.md
@@ -29,7 +29,7 @@ av hvordan en kan ta i bruk mock-miljøet:
 
 - [efm-mocks](https://github.com/felleslosninger/efm-mocks) (ekstern lenke)
 
-### Teste i eFormidlings testmiljø (QA)
+### Teste i eFormidlings testmiljø
 
 For å verifisere at en integrasjon mot eFormidling fungerer er det nødvendig å teste i eFormidlings testmiljø. 
 

--- a/_docs/eFormidling/installasjon/forberede_installasjon.md
+++ b/_docs/eFormidling/installasjon/forberede_installasjon.md
@@ -136,7 +136,7 @@ bruker.
 Se beskrivelser inkludert IP-adresser for tjenestene integrasjonspunktet bruker:
 
 - [eFormidling Produksjon](../Miljo/produksjon)
-- [eFormidling QA](../Miljo/qa)
+- [eFormidling Test](../Miljo/test)
 
 En må også tillate inngående trafikk til integrasjonspunktet fra tjenesten(e) som skal benytte integrasjonspunktet.
 Integrasjonspunktets grensesnitt er som standard tilgjengelig på port `9093`, men kan settes til noe annet dersom

--- a/_docs/eFormidling/installasjon/installasjon.md
+++ b/_docs/eFormidling/installasjon/installasjon.md
@@ -130,17 +130,17 @@ difi.move.feature.enableDPE=false
 
 ### Valgfri konfigurasjon
 
-#### Miljø (produksjon eller QA)
+#### Miljø (produksjon eller test)
 *Valgfritt*
 
 Tilgjengelige miljø:
 
 - [eForidling Produksjon](../Miljo/produksjon)
-- [eFormidling QA](../Miljo/qa)
+- [eFormidling Test](../Miljo/test)
 
 | Egenskap               | Beskrivelse                                                                                                                                                  | Standardverdi |
 |------------------------|--------------------------------------------------------------------------------------------------------------------------------------------------------------|---------------|
-| spring.profiles.active | Produksjon (`production`) eller QA (`staging`). Må spesifiseres som miljøvariabel eller Java-parameter. Kan ikke spesifiseres som del av konfigurasjonsfil.  | production    |
+| spring.profiles.active | Produksjon (`production`) eller test (`staging`). Må spesifiseres som miljøvariabel eller Java-parameter. Kan ikke spesifiseres som del av konfigurasjonsfil.  | production    |
 
 Eksempel:
 


### PR DESCRIPTION
Hei Daniel, ser du over endringane eg har gjort ifm. migrering til ny plattform?

Trur du det går greit å berre omdøype _qa_ til _test_ slik eg har gjort, eller burde me omtale _test_ som _test (tidligare qa)_ ei stund?