### PR TITLE
(eformidling) fiks test miljø lenker

### DIFF
--- a/_docs/eFormidling/Testing/index.md
+++ b/_docs/eFormidling/Testing/index.md
@@ -152,10 +152,10 @@ Brukernavn og passord for testbrukere til virksomhetene over fåes ved å kontak
 
 ### Lenker til testmiljø
 
-- Altinn <a href="https://tt02.altinn.no">https://tt02.altinn.no</a>
-- eBoks (Digital Post til Innbyggere) <a href="http://demo2-www.e-boks.no/">http://demo2-www.e-boks.no/</a>
-- Digipost (Digital Post til Innbyggere) <a href="http://www.difitest.digipost.no/">http://www.difitest.digipost.no/</a>
-- KS SvarUt og SvarInn <a href="https://test.svarut.ks.no/tjenester/">https://test.svarut.ks.no/tjenester/</a>
+- Altinn <https://tt02.altinn.no>
+- eBoks (Digital Post til Innbyggere) <http://demo2-www.e-boks.no/>
+- Digipost (Digital Post til Innbyggere) <http://www.difitest.digipost.no/>
+- KS SvarUt og SvarInn <https://test.svarut.ks.no/>
 
 ## Neste steg
 


### PR DESCRIPTION
1. Endre til \<link\> syntax slik at http lenker redirecter til http istedenfor https i chrome.

2. fjern /tjenester fra KS SvarUt og SvarInn URL. (/tjenester gir 404 dersom man allerede er logget inn i Altinn test miljøet)

**NB! kun testet i GitHub markdown, burde også testes på gh-pages.**