### PR TITLE
docs: clarify expiration behaviour in Maskinporten /token endpoint

### DIFF
--- a/_docs/Maskinporten/maskinporten_protocol_token.md
+++ b/_docs/Maskinporten/maskinporten_protocol_token.md
@@ -102,7 +102,7 @@ The token is a JWT with the following structure:
 | consumer | The organization number, in ISO6523 notation, of the organization who is the legal consumer  of the token/API.  This value is always present.  In most cases, this organization will also be the Data Controller according to the GDPR. | see below |
 | scope | A list of scopes the access_token is bound to.   |
 | token_type | Type of token. Only bearer supported. | `Bearer`|
-| exp | Expire - Timestamp when this token should not be trusted any more.  |
+| exp | Expire - Timestamp when this token should not be trusted any more. **Note: This is not respected by the auth server. The configured expiration time on the client decides the expiration of the token.** |
 | iat | Timestamp when this token was issued.  |
 | jti | jwt id - unique identifer for a given token  |
 


### PR DESCRIPTION
Clarify the current behaviour of the exp parameter in the input JWT. After some tinkering I have concluded that this is the current behaviour. 

I could submit this as a bug issue, but I don't know if the auth server itself has a public repository. 

If I set `exp` to anything more than 180 seconds I get a 400 error, even if the client allows for longer lived tokens.