### PR TITLE
Revise localhost usage note for production environments

### DIFF
--- a/_docs/idporten/oidc/oidc_func_clientreg.md
+++ b/_docs/idporten/oidc/oidc_func_clientreg.md
@@ -213,7 +213,7 @@ Klienter som skal innvolvere brukeren (altså brukerens browser) må ha følgend
 | frontchannel_logout_session_required | Nei |Flagg som bestemmer om parameterne for issuer og sesjons-id skal sendes med frontchannel_logout_uri. Dersom ikke satt, så vil ikke 'sid' bli inkludert i id_token. |
 | logo | Nei |Logo som vises i innloggingsbildete utveksles p.t. manuelt |
 
-*NB! Bruk av localhost er ikke tillatt i produksjonsmiljøet for andre enn native klienter. Skal du registrere en localhost uri i testmiljøet, må denne være http:// og ikke https://.
+*NB! Bruk av localhost er ikke tillatt i produksjonsmiljøet for andre enn native klienter. Vi anbefaler sterkt å bruke IP-adresse istedenfor localhost literal. 127.0.0.1 (IPv4) eller 0:0:0:0:0:0:0:1 / [::1] (IPv6).
 
 ** Frontchannel logout uri må ha samme domene som en registrert redirect uri.
 


### PR DESCRIPTION
Updated note regarding localhost usage in production environments to recommend using IP addresses instead.