### PR TITLE
Clean up comments in Maskinporten documentation

### DIFF
--- a/_docs/Maskinporten/index.md
+++ b/_docs/Maskinporten/index.md
@@ -9,9 +9,3 @@ Maskinporten er en tjeneste som tilbyr en enkel modell for API-sikring basert p�
 
 Maskinporten lar API-tilbydere definere tilganger til sine API, modellert som scopes, basert på konsumenten sine organisasjonsnummer.
 Dette kan gjøres via Maskinporten sine selvbetjeningsAPI eller webløsning.
-
-<!---
-Usynlig kommentar
---->
-
-Synlig kommentar


### PR DESCRIPTION
Removed invisible comment and visible comment from the documentation. These were probably remnants from a template.