### PR TITLE
Fjern whitespace slik at tekst ikke tolkes som MD liste

### DIFF
--- a/_docs/Maskinporten/maskinporten_overordnet.md
+++ b/_docs/Maskinporten/maskinporten_overordnet.md
@@ -59,7 +59,7 @@ graph LR
      ny[Klient]
   end
   Maskinporten -->|2.utsteder token med tildelt scope|ny
-  ny -->|1. forspør tilgang til scope|Maskinporten
+  ny -->|1.forspør tilgang til scope|Maskinporten
   ny -->|3.bruker token mot|API
 </div>
 


### PR DESCRIPTION
I dag tegnes figuren slik: 
<img width="626" height="246" alt="image" src="https://github.com/user-attachments/assets/187d6b21-c9a8-4157-af23-b4dec8b50c93" />
> Unsupported markdown: list
