### PR TITLE
ID-6251: Clarify `locale`, `given_name`, and `family_name` attributes 

### DIFF
--- a/_docs/idporten/oidc/oidc_protocol_id_token.md
+++ b/_docs/idporten/oidc/oidc_protocol_id_token.md
@@ -88,7 +88,7 @@ OuFJaVWQvLY9... <signaturverdi> ...isvpDMfHM3mkI
 | iat | Timestamp when this token was issued. If different from `auth_time`, this indicates a federated/sso login. |
 | exp | Expire - Timestamp when this token should not be trusted any more.  |
 | jti | jwt id - unique identifer for a given token  |
-| locale | The language selected by the user during the authentication in ID-porten. ISO 639-1 values are: nb (Norwegian Bokmål), nn (Norwegian Nynorsk), en (English), se (Northern Sami)|
+| locale | The language selected by the user during the authentication in ID-porten. ISO 639-1 values are: nb (Norwegian Bokmål), nn (Norwegian Nynorsk), en (English), se (Northern Sami). Only included if the *profile* scope was requested.|
 | sid | session id - an unique identifier for end user session at ID-porten. Clients should store the value to be able to handle frontchannel logout notifications. Note that `sid` will only be included if the client is [registered](oidc_func_clientreg.html) with `frontchannel_logout_session_required`.  |
 
 Additional claims that may be added if the eid supplier provides them and the client has requested the `profile` scope:

--- a/_docs/idporten/oidc/oidc_protocol_userinfo.md
+++ b/_docs/idporten/oidc/oidc_protocol_userinfo.md
@@ -33,9 +33,9 @@ The response is a JSON structure with claims:
 |-|-|
 |sub   | "subject identifier" - an unique identifier for the authenticated user.  The value is *pairwise*, meaning a given client will always get the same value, whilst different clients do not get equal values for the same user.   |
 |pid   |Norwegian national id number - always present unless a pseudonymous scope was requested. |
-|locale| The language used during authentication|
-|given_name| The given name of the user. Only returned if the access token contains the claim `clm` with the claim `given_name`.|
-|family_name| The family name of the user. Only returned if the access token contains the claim `clm` with the claim `family_name`.|
+|locale| The language used during authentication. Only returned if the *profile* scope was requested.|
+|given_name| The given name of the user. Only returned if the *profile* scope was requested and the access token contains the claim `clm` with the claim `given_name`.|
+|family_name| The family name of the user. Only returned if the *profile* scope was requested and the access token contains the claim `clm` with the claim `family_name`.|
 
 ```
 {


### PR DESCRIPTION
…fy they require the `profile` scope.